### PR TITLE
Ajout bouchon GPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
-GENDLOC
-=======
+# GENDLOC
 
     vagrant up
     vagrant ssh
     cd /vagrant
 
 Éditer le fichier *app/config/parameters.yml* et modifier la variable devmail
-pour recevoir les mails de dev. (envoi sms).
+pour recevoir les mails de dev. (simulation sms).
 
     php bin/console server:run 0.0.0.0:8000
     
 Allez dans votre navigateur à l'adresse *http://127.0.0.1:8000* et tester !
+
+## Identifiant 
+
+### Administrateur
+
+Login *admin* password *admin*
+
+### Opérateur
+
+Login *ope* password *ope*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,10 @@ Vagrant.configure(2) do |config|
     php bin/console doctrine:schema:update -f
     sudo -u postgres psql -c "create extension pgcrypto" db_gendloc
     sudo -u postgres psql -c "create extension postgis" db_gendloc
-    sudo -u postgres psql -c "insert into app_unites (id, name, tel, coordinates) values (1, 'SECOURSMONT', '00', ST_GeomFromText('point(2.271 48.815 )'));" db_gendloc
+    sudo -u postgres psql -c "insert into app_unites (id, name, tel, coordinates) values (1, 'SECOURSMONT', '00', ST_GeomFromText('point(2.271 48.815)'));" db_gendloc
     sudo -u postgres psql -c "insert into app_users (id, username, password, email, is_active, unite, role) values (1, 'admin', crypt('admin', 'bcrypt'), 'admin@gend.loc', true, 1, 'ROLE_ADMIN');" db_gendloc
+    sudo -u postgres psql -c "insert into app_users (id, username, password, email, is_active, unite, role) values (2, 'ope', crypt('ope', 'bcrypt'), 'ope@gend.loc', true, 1, 'ROLE_OPERATOR');" db_gendloc
+    sudo -u postgres psql -c "ALTER TABLE app_geoloc ADD COLUMN coordinates geometry(Point,4326);" db_gendloc
+    sudo -u postgres psql -c "ALTER TABLE app_geoloc ALTER COLUMN id SET DEFAULT nextval('"app_geoloc_id_seq"');" db_gendloc
   SHELL
 end

--- a/src/AppBundle/Services/envoi_sms.php
+++ b/src/AppBundle/Services/envoi_sms.php
@@ -87,8 +87,9 @@ else
            "SECOURS EN MONTAGNE\r\n*" .
            " Vérifier GPS et DATA à ON\r\n".
            "\r\n* Accepter le partage\r\n" .
-           "* Patienter\r\n* http://%s%s %s",
-           $this->container->get('router')->getContext()->getHost(),
+           "* Patienter\r\n* http://%s:%s%s %s",
+           $request->getHost(),
+           $request->getPort(),
            $this->generateUrl('position', array('c' => $lastid), true),
            $unite);
 	}

--- a/src/AppBundle/Services/req_commune.php
+++ b/src/AppBundle/Services/req_commune.php
@@ -2,34 +2,38 @@
 // Fichier qui permet de récupérer les données commune et compétence dans les tables
 
 // boucle sur l'ensemble des SMS du jour présent dans le tableau $data de taille $size défini dans day_sms.php
-for($i=0;$i<$size;$i++)
-{
-    if (isset($data[$i]['lat']))
-    {
-        // récupération des données de latitude et de longitude de la ligne i
-        $lat=$data[$i]['lat'];
-        $long=$data[$i]['lng'];
-        
-        // connection à la base de données
-        $conn = $this->get('database_connection');
-        
-        // définition du point à étudier
-        $loc ="POINT(".$long." ".$lat.")";
-        
-        // requête de recherche dans les tables pour récupérer la commune et l'unité compétente
-        $quer ="SELECT app_commune.commune, service FROM app_commune INNER JOIN app_competence ON app_commune.ref_insee = app_competence.insee WHERE ST_Contains(geom,ST_GeometryFromText('$loc',4326))";
-        
-        // Récupération du résultat de la requête
-        $com_bp = $conn->fetchAll($quer);
+for ($i=0; $i<$size; $i++) {
+    if (!$this->container->getParameter('kernel.environment')=='dev') {
+        if (isset($data[$i]['lat'])) {
+            // récupération des données de latitude et de longitude de la ligne i
+            $lat=$data[$i]['lat'];
+            $long=$data[$i]['lng'];
 
-        // ajout des données dans data
-        $data[$i]['commune'] = $com_bp[0]['commune'];
-        $data[$i]['service'] = $com_bp[0]['service'];
+            // connection à la base de données
+            $conn = $this->get('database_connection');
 
-    } else { // si la latitude n'est pas définie, on ajoute juste les champs commune et service pour qu'il n'y ait pas de bug dans les .twig
+            // définition du point à étudier
+            $loc ="POINT(".$long." ".$lat.")";
+
+            // requête de recherche dans les tables pour récupérer la commune et l'unité compétente
+            $quer ="SELECT app_commune.commune, service FROM app_commune INNER JOIN app_competence ON app_commune.ref_insee = app_competence.insee WHERE ST_Contains(geom,ST_GeometryFromText('$loc',4326))";
+
+            // Récupération du résultat de la requête
+            $com_bp = $conn->fetchAll($quer);
+
+            // ajout des données dans data
+            $data[$i]['commune'] = $com_bp[0]['commune'];
+            $data[$i]['service'] = $com_bp[0]['service'];
+
+            // si la latitude n'est pas définie, on ajoute juste les champs commune et service pour qu'il n'y ait pas de bug dans les .twig
+        } else {
+            $data[$i]['commune'] = "";
+            $data[$i]['service'] = "";
+        } // end if
+    }else{
         $data[$i]['commune'] = "";
         $data[$i]['service'] = "";
-    } // end if
+    }
 } // end for
 
 ?>


### PR DESCRIPTION
Toujours dans l'optique du HackGN2016
- Ajout d'un utilisateur ope (ROLE_OPERATEUR) dans le Vagrantfile
- Si app en dev alors le GPS est "simulé" avec les x,y de la DGGN. (A changer, à mettre dans un fichier de conf.) 
- Ajout de la collone "coordinates" de type Point (geom) dans la table app_geoloc

A noter : 

La partie qui permet de centrer l'opérateur sur sa zone de compétence
est désactivée en dev car la table app_commune n'existe pas. (A réactive
lorsque le 'bug' sera corrigé.)
